### PR TITLE
Fix NaN TimeOfFlight at negative yOffset & low angle

### DIFF
--- a/Assets/Scripts/ProjectileMath.cs
+++ b/Assets/Scripts/ProjectileMath.cs
@@ -61,9 +61,20 @@ public static class ProjectileMath
     {
         float ySpeed = speed * Mathf.Sin(angle);
 
-        float time = (ySpeed + Mathf.Sqrt((ySpeed * ySpeed) + 2 * gravity * yOffset)) / gravity;
+        float discriminant = (ySpeed * ySpeed) - 2 * gravity * yOffset;
+        if (discriminant < 0f)
+            return float.NaN; // no valid solution
 
-        return time;
+        float sqrtDisc = Mathf.Sqrt(discriminant);
+
+        // Two possible times: (ySpeed ± sqrtDisc) / gravity
+        float t1 = (ySpeed + sqrtDisc) / gravity;
+        float t2 = (ySpeed - sqrtDisc) / gravity;
+
+        // Return the positive, larger one (impact time)
+        float time = Mathf.Max(t1, t2);
+
+        return time >= 0f ? time : float.NaN;
     }
 
     /// <summary>


### PR DESCRIPTION
`TimeOfFlight` currently returns NaN in some cases, particularly when firing angle is low and the target Y offset is negative.

The function has to solve a quadradic and it gets the solution for the positive root, but sometimes the correct solution is the one for negative root.

Example for testing:
```csharp
var durationTest = ProjectileMath.TimeOfFlight(5, 5 * Mathf.Deg2Rad, -1.5f, 9.8);
Debug.Log($"angle: 5°, speed: 5m/s, offsetY: -1.5m, gravity: 9.8m/s², duration: {durationTest:F2}s");
```

Using current implementation, the `TimeOfFlight` returns NaN and the output is:
> angle: 5°, speed: 5m/s, offsetY: -1.5m, gravity: 9,8m/s², duration: NaNs

Using this PR's implementation, `TimeOfFlight` returns correct result, and the output becomes:
> angle: 5°, speed: 5m/s, offsetY: -1.5m, gravity: 9,8m/s², duration: 0,60s